### PR TITLE
make dialog component consistent with others

### DIFF
--- a/components/base/dialog/dialog.templ
+++ b/components/base/dialog/dialog.templ
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"github.com/iota-agency/iota-sdk/components/base/button"
 	"github.com/iota-agency/iota-sdk/pkg/presentation/templates/icons"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 )
 
 type Props struct {
-	Icon      templ.Component
-	Heading   string
-	Text      string
-	Localizer *i18n.Localizer
-	Action    string
-	Attrs     templ.Attributes
+	Icon        templ.Component
+	Heading     string
+	Text        string
+	Action      string
+	Attrs       templ.Attributes
+	CancelText  string
+	ConfirmText string
 }
 
 templ Confirmation(p *Props) {
@@ -21,7 +21,7 @@ templ Confirmation(p *Props) {
 		<dialog class="dialog shadow-lg mb-0 rounded-b-none md:mb-auto md:rounded-b-lg" x-bind="dialog" { p.Attrs... }>
 			<form method="dialog">
 				<header class="flex items-center gap-3 justify-between px-4 py-3 border-b border-primary">
-					<h3 class="font-medium">{ p.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: p.Heading}) }</h3>
+					<h3 class="font-medium">{ p.Heading }</h3>
 					@button.Secondary(button.Props{Size: button.SizeSM, Fixed: true, Rounded: true}) {
 						@icons.XCircle(icons.Props{Size: "20"})
 					}
@@ -34,7 +34,7 @@ templ Confirmation(p *Props) {
 					}
 					if p.Text != "" {
 						<p class="text-center">
-							{ p.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: p.Text}) }
+							{ p.Text }
 						</p>
 					}
 					{ children... }
@@ -42,10 +42,10 @@ templ Confirmation(p *Props) {
 				<footer class="px-4 py-3">
 					<menu class="flex gap-3">
 						@button.Secondary(button.Props{Class: "flex-1 justify-center", Attrs: templ.Attributes{"value": "cancel"}}) {
-							{ p.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Cancel"}) }
+							{ p.CancelText }
 						}
 						@button.Primary(button.Props{Class: "flex-1 justify-center", Attrs: templ.Attributes{"value": "confirm"}}) {
-							{ p.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Delete"}) }
+							{ p.ConfirmText }
 						}
 					</menu>
 				</footer>

--- a/modules/finance/templates/pages/expense_categories/edit.templ
+++ b/modules/finance/templates/pages/expense_categories/edit.templ
@@ -111,11 +111,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "ExpenseCategories.Single.Delete",
-			Text:      "ExpenseCategories.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-category-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("ExpenseCategories.Single.Delete"),
+			Text:        props.T("ExpenseCategories.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-category-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/modules/finance/templates/pages/expenses/edit.templ
+++ b/modules/finance/templates/pages/expenses/edit.templ
@@ -115,11 +115,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Expenses.Single.Delete",
-			Text:      "Expenses.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-expense-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Expenses.Single.Delete"),
+			Text:        props.T("Expenses.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-expense-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/modules/finance/templates/pages/moneyaccounts/edit.templ
+++ b/modules/finance/templates/pages/moneyaccounts/edit.templ
@@ -124,11 +124,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Accounts.Single.Delete",
-			Text:      "Accounts.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-account-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Accounts.Single.Delete"),
+			Text:        props.T("Accounts.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-account-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/modules/finance/templates/pages/payments/edit.templ
+++ b/modules/finance/templates/pages/payments/edit.templ
@@ -110,11 +110,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Payments.Single.DeletePayment",
-			Text:      "Payments.Single.DeletePaymentConfirmation",
-			Localizer: props.PageContext.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-payment-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Payments.Single.DeletePayment"),
+			Text:        props.T("Payments.Single.DeletePaymentConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-payment-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
      if (target.returnValue === "confirm") {

--- a/modules/warehouse/templates/pages/orders/edit.templ
+++ b/modules/warehouse/templates/pages/orders/edit.templ
@@ -75,11 +75,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "WarehouseOrders.Single.Delete",
-			Text:      "WarehouseOrders.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-unit-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("WarehouseOrders.Single.Delete"),
+			Text:        props.T("WarehouseOrders.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-unit-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/modules/warehouse/templates/pages/positions/edit.templ
+++ b/modules/warehouse/templates/pages/positions/edit.templ
@@ -116,11 +116,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "WarehousePositions.Single.Delete",
-			Text:      "WarehousePositions.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-position-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("WarehousePositions.Single.Delete"),
+			Text:        props.T("WarehousePositions.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-position-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/modules/warehouse/templates/pages/products/edit.templ
+++ b/modules/warehouse/templates/pages/products/edit.templ
@@ -103,11 +103,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Products.Single.Delete",
-			Text:      "Products.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-product-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Products.Single.Delete"),
+			Text:        props.T("Products.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-product-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
      if (target.returnValue === "confirm") {

--- a/modules/warehouse/templates/pages/units/edit.templ
+++ b/modules/warehouse/templates/pages/units/edit.templ
@@ -95,11 +95,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "WarehouseUnits.Single.Delete",
-			Text:      "WarehouseUnits.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-unit-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("WarehouseUnits.Single.Delete"),
+			Text:        props.T("WarehouseUnits.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-unit-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/pkg/presentation/templates/pages/employees/edit.templ
+++ b/pkg/presentation/templates/pages/employees/edit.templ
@@ -106,11 +106,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Employees.Single.Delete",
-			Text:      "Employees.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-employee-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Employees.Single.Delete"),
+			Text:        props.T("Employees.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-employee-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {

--- a/pkg/presentation/templates/pages/projects/edit.templ
+++ b/pkg/presentation/templates/pages/projects/edit.templ
@@ -96,11 +96,12 @@ templ Edit(props *EditPageProps) {
 	@layouts.Authenticated(props.PageContext) {
 		@EditForm(props)
 		@dialog.Confirmation(&dialog.Props{
-			Heading:   "Projects.Single.Delete",
-			Text:      "Projects.Single.DeleteConfirmation",
-			Localizer: props.Localizer,
-			Icon:      icons.Trash(icons.Props{Size: "20"}),
-			Action:    "open-delete-expense-confirmation",
+			CancelText:  props.T("Cancel"),
+			ConfirmText: props.T("Delete"),
+			Heading:     props.T("Projects.Single.Delete"),
+			Text:        props.T("Projects.Single.DeleteConfirmation"),
+			Icon:        icons.Trash(icons.Props{Size: "20"}),
+			Action:      "open-delete-expense-confirmation",
 			Attrs: templ.Attributes{
 				"@closing": `({target}) => {
 					if (target.returnValue === "confirm") {


### PR DESCRIPTION
- removed localizer prop from dialog props to make it consistent with components that take already translated texts instead of translation key.
- added two new props: `CancelText` and `ConfirmText`